### PR TITLE
remove implicit waiting, implement explicit waiting

### DIFF
--- a/protractor/headless.config.ts
+++ b/protractor/headless.config.ts
@@ -13,7 +13,7 @@ export const config: Config = {
   },
   onPrepare: () => {
     browser.ignoreSynchronization = true;
-    browser.manage().timeouts().implicitlyWait(4000);
+    browser.manage().timeouts().implicitlyWait(0);
     reporter();
   },
   getPageTimeout: 30000,

--- a/protractor/local.config.ts
+++ b/protractor/local.config.ts
@@ -7,7 +7,7 @@ export const config: Config = {
   SELENIUM_PROMISE_MANAGER: false,
   onPrepare: () => {
     browser.ignoreSynchronization = true;
-    browser.manage().timeouts().implicitlyWait(4000);
+    browser.manage().timeouts().implicitlyWait(0);
     reporter();
   },
   getPageTimeout: 30000,

--- a/src/page/product-added-modal.page.ts
+++ b/src/page/product-added-modal.page.ts
@@ -1,4 +1,4 @@
-import { $, ElementFinder } from 'protractor';
+import { $, ElementFinder, ExpectedConditions, browser } from 'protractor';
 
 export class ProductAddedModalPage {
   private checkoutButton: ElementFinder;
@@ -8,6 +8,7 @@ export class ProductAddedModalPage {
   }
 
   public async goToCheckoutButton(): Promise<void> {
+    await browser.wait(ExpectedConditions.elementToBeClickable(this.checkoutButton), 4000);
     await this.checkoutButton.click();
   }
 }

--- a/src/page/product-list.page.ts
+++ b/src/page/product-list.page.ts
@@ -1,4 +1,4 @@
-import { $, ElementFinder } from 'protractor';
+import { $, ElementFinder, ExpectedConditions, browser } from 'protractor';
 
 export class ProductListPage {
   private addToCart: ElementFinder;
@@ -8,6 +8,7 @@ export class ProductListPage {
   }
 
   public async goToAddToCart(): Promise<void> {
+    await browser.wait(ExpectedConditions.elementToBeClickable(this.addToCart), 4000);
     await this.addToCart.click();
   }
 }


### PR DESCRIPTION
From my understanding of what happened: some of the page components pretty much load immediately, while others take a little bit of time. To that end, we usually want to remove implicit waiting to immediately deal with those cases, while we implement explicit waiting for cases that we know for a fact take a little bit of time before they work as they're intended (and we add a timeout time so we aren't stuck waiting forever).

![image](https://user-images.githubusercontent.com/38226757/88981210-1dc5a280-d28b-11ea-8d38-c05751b47a0c.png)
![image](https://user-images.githubusercontent.com/38226757/88981243-27e7a100-d28b-11ea-8087-3a2875b28aa3.png)
