### PR TITLE
improve pom css-locators

### DIFF
--- a/src/page/address-step.page.ts
+++ b/src/page/address-step.page.ts
@@ -4,7 +4,7 @@ export class AddressStepPage {
   private checkoutButton: ElementFinder;
 
   constructor () {
-    this.checkoutButton = $('#center_column > form > p > button > span');
+    this.checkoutButton = $('#center_column > form > p > button');
   }
 
   public async goToShippingPage(): Promise<void> {

--- a/src/page/address-step.page.ts
+++ b/src/page/address-step.page.ts
@@ -4,7 +4,7 @@ export class AddressStepPage {
   private checkoutButton: ElementFinder;
 
   constructor () {
-    this.checkoutButton = $('#center_column > form > p > button');
+    this.checkoutButton = $('button[name="processAddress"]');
   }
 
   public async goToShippingPage(): Promise<void> {

--- a/src/page/bank-payment.page.ts
+++ b/src/page/bank-payment.page.ts
@@ -4,7 +4,7 @@ export class BankPaymentPage {
   private confirmButton: ElementFinder;
 
   constructor () {
-    this.confirmButton = $('#cart_navigation > button > span');
+    this.confirmButton = $('#cart_navigation > button');
   }
 
   public async confirmOrder(): Promise<void> {

--- a/src/page/bank-payment.page.ts
+++ b/src/page/bank-payment.page.ts
@@ -1,10 +1,11 @@
-import { $, ElementFinder } from 'protractor';
+import { ElementFinder, element, by } from 'protractor';
 
 export class BankPaymentPage {
   private confirmButton: ElementFinder;
 
   constructor () {
-    this.confirmButton = $('#cart_navigation > button');
+    // this.confirmButton = $('#cart_navigation > button');
+    this.confirmButton = element(by.cssContainingText('span', 'I confirm my order'));
   }
 
   public async confirmOrder(): Promise<void> {

--- a/src/page/menu-content.page.ts
+++ b/src/page/menu-content.page.ts
@@ -4,7 +4,7 @@ export class MenuContentPage {
   private tShirtMenu: ElementFinder;
 
   constructor () {
-    this.tShirtMenu = $('#block_top_menu > ul > li:nth-child(3) > a');
+    this.tShirtMenu = $('#block_top_menu > ul > li > a[title="T-shirts"]');
   }
 
   public async goToTShirtMenu(): Promise<void> {

--- a/src/page/order-summary.page.ts
+++ b/src/page/order-summary.page.ts
@@ -4,7 +4,7 @@ export class OrderSummaryPage {
   private confirmationText: ElementFinder;
 
   constructor() {
-    this.confirmationText = $('#center_column > div > p > strong');
+    this.confirmationText = $('p.cheque-indent > strong');
   }
 
   public getOrderText() {

--- a/src/page/order-summary.page.ts
+++ b/src/page/order-summary.page.ts
@@ -4,7 +4,7 @@ export class OrderSummaryPage {
   private confirmationText: ElementFinder;
 
   constructor() {
-    this.confirmationText = $('p.cheque-indent > strong');
+    this.confirmationText = $('p.cheque-indent');
   }
 
   public getOrderText() {

--- a/src/page/payment-step.page.ts
+++ b/src/page/payment-step.page.ts
@@ -4,7 +4,7 @@ export class PaymentStepPage {
   private bankPayButton: ElementFinder;
 
   constructor () {
-    this.bankPayButton = $('#HOOK_PAYMENT > div:nth-child(1) > div > p > a');
+    this.bankPayButton = $('a.bankwire');
   }
 
   public async goToBankPaymentPage(): Promise<void> {

--- a/src/page/product-added-modal.page.ts
+++ b/src/page/product-added-modal.page.ts
@@ -4,7 +4,7 @@ export class ProductAddedModalPage {
   private checkoutButton: ElementFinder;
 
   constructor () {
-    this.checkoutButton = $('[style*="display: block;"] .button-container > a');
+    this.checkoutButton = $('a.btn.btn-default.button.button-medium');
   }
 
   public async goToCheckoutButton(): Promise<void> {

--- a/src/page/product-added-modal.page.ts
+++ b/src/page/product-added-modal.page.ts
@@ -4,7 +4,7 @@ export class ProductAddedModalPage {
   private checkoutButton: ElementFinder;
 
   constructor () {
-    this.checkoutButton = $('a.btn.btn-default.button.button-medium');
+    this.checkoutButton = $('a[title="Proceed to checkout"]');
   }
 
   public async goToCheckoutButton(): Promise<void> {

--- a/src/page/product-list.page.ts
+++ b/src/page/product-list.page.ts
@@ -4,7 +4,7 @@ export class ProductListPage {
   private addToCart: ElementFinder;
 
   constructor () {
-    this.addToCart = $('#center_column a.button.ajax_add_to_cart_button.btn.btn-default');
+    this.addToCart = $('a.button.ajax_add_to_cart_button.btn.btn-default');
   }
 
   public async goToAddToCart(): Promise<void> {

--- a/src/page/shipping-step.page.ts
+++ b/src/page/shipping-step.page.ts
@@ -6,7 +6,7 @@ export class ShippingStepPage {
 
   constructor () {
     this.tosRadioButton = $('#cgv');
-    this.checkoutButton = $('#form > p > button > span');
+    this.checkoutButton = $('#form > p > button');
   }
 
   public async goToPaymentPage(): Promise<void> {

--- a/src/page/shipping-step.page.ts
+++ b/src/page/shipping-step.page.ts
@@ -6,7 +6,7 @@ export class ShippingStepPage {
 
   constructor () {
     this.tosRadioButton = $('#cgv');
-    this.checkoutButton = $('#form > p > button');
+    this.checkoutButton = $('button[name="processCarrier"]');
   }
 
   public async goToPaymentPage(): Promise<void> {

--- a/src/page/sign-in-step.page.ts
+++ b/src/page/sign-in-step.page.ts
@@ -6,7 +6,7 @@ export class SignInStepPage {
   private passwordField: ElementFinder;
 
   constructor () {
-    this.signInButton = $('#SubmitLogin > span');
+    this.signInButton = $('#SubmitLogin');
     this.emailField = $('#email');
     this.passwordField = $('#passwd');
   }

--- a/src/page/summary-step.page.ts
+++ b/src/page/summary-step.page.ts
@@ -4,7 +4,7 @@ export class SummaryStepPage {
   private checkoutButton: ElementFinder;
 
   constructor () {
-    this.checkoutButton = $('.cart_navigation a.standard-checkout');
+    this.checkoutButton = $('a.standard-checkout');
   }
 
   public async goToCheckoutSignIn(): Promise<void> {


### PR DESCRIPTION
## MenuContentPage
While there are two links with a title of T-shirts and both lead to the same page, only one of them is directly below an unordered list. The other one is below two unordered lists.

## ProductListPage
On the one hand, the class has many names, which makes it a very specific thing to find. On the other hand, I think this would NOT work if the page had more than one product available, because it'd likely use the same classes for its ADD TO CART button.

## ProductAddedModalPage
At risk of falling into a problem (because again, this probably doesn't work if we had more than one product here, unless the modal is used for all products and the info it shows changes each time it opens), there is only one link that has the specific class. Two buttons share the class, but we are interested in the link.

## SummaryStepPage
Only the button has the class "standard-checkout" (and unlike the previous two pages, it's not likely to be repeated elsewhere for any reason)

## SignInStepPage
Email and password can stay as they are because both are really unique IDs.
We can remove the span from the previous signInButton because it's inside the button that has #SubmitLogin itself, so that can be clicked on its own.

## AddressStepPage
By the same reasons as above, remove the span because it's not needed in this case.

## ShippingStepPage
The TOS check can stay as is. Remove the span from the checkoutButton locator because, once again, not needed.

## PaymentStepPage:
Only one thing in the whole page has the class bankwire.

## BankPaymentPage
Remove span, as what matters is clicking the button.

## OrderSummaryPage
Only one p with class cheque-indent.